### PR TITLE
Update `informalsystems/hermes` to v1.2.0

### DIFF
--- a/ibc/README.md
+++ b/ibc/README.md
@@ -32,11 +32,6 @@ Before setting up relayer you need to make sure you already have:
 sudo apt update && sudo apt upgrade -y
 ```
 
-## Install dependencies
-```
-sudo apt install unzip -y
-```
-
 ## Make hermes home dir
 ```
 mkdir $HOME/.hermes
@@ -44,9 +39,9 @@ mkdir $HOME/.hermes
 
 ## Download Hermes
 ```
-wget https://github.com/informalsystems/ibc-rs/releases/download/v1.0.0/hermes-v1.0.0-x86_64-unknown-linux-gnu.tar.gz
+wget -nv https://github.com/informalsystems/hermes/releases/download/v1.2.0/hermes-v1.2.0-x86_64-unknown-linux-gnu.tar.gz
 mkdir -p $HOME/.hermes/bin
-tar -C $HOME/.hermes/bin/ -vxzf hermes-v1.0.0-x86_64-unknown-linux-gnu.tar.gz
+tar -C $HOME/.hermes/bin/ -vxzf hermes-v1.2.0-x86_64-unknown-linux-gnu.tar.gz
 echo 'export PATH="$HOME/.hermes/bin:$PATH"' >> $HOME/.bash_profile
 source $HOME/.bash_profile
 ```

--- a/ibc/TESTNETS.md
+++ b/ibc/TESTNETS.md
@@ -32,11 +32,6 @@ Before setting up relayer you need to make sure you already have:
 sudo apt update && sudo apt upgrade -y
 ```
 
-## Install dependencies
-```
-sudo apt install unzip -y
-```
-
 ## Make hermes home dir
 ```
 mkdir $HOME/.hermes
@@ -44,9 +39,9 @@ mkdir $HOME/.hermes
 
 ## Download Hermes
 ```
-wget https://github.com/informalsystems/ibc-rs/releases/download/v1.0.0/hermes-v1.0.0-x86_64-unknown-linux-gnu.tar.gz
+wget -nv https://github.com/informalsystems/hermes/releases/download/v1.2.0/hermes-v1.2.0-x86_64-unknown-linux-gnu.tar.gz
 mkdir -p $HOME/.hermes/bin
-tar -C $HOME/.hermes/bin/ -vxzf hermes-v1.0.0-x86_64-unknown-linux-gnu.tar.gz
+tar -C $HOME/.hermes/bin/ -vxzf hermes-v1.2.0-x86_64-unknown-linux-gnu.tar.gz
 echo 'export PATH="$HOME/.hermes/bin:$PATH"' >> $HOME/.bash_profile
 source $HOME/.bash_profile
 ```

--- a/quicksilver/killerqueen-tasks/crazy_little_thing_called_love.md
+++ b/quicksilver/killerqueen-tasks/crazy_little_thing_called_love.md
@@ -24,8 +24,8 @@ This sould be installed and executed on `ica` cosmos validator node
 ## Install hermes
 ```
 cd ~
-wget https://github.com/informalsystems/ibc-rs/releases/download/v0.15.0/hermes-v0.15.0-x86_64-unknown-linux-gnu.zip
-unzip hermes-v0.15.0-x86_64-unknown-linux-gnu.zip
+wget https://github.com/informalsystems/hermes/releases/download/v1.2.0/hermes-v1.2.0-x86_64-unknown-linux-gnu.zip
+unzip hermes-v1.2.0-x86_64-unknown-linux-gnu.zip
 sudo mv hermes /usr/local/bin
 hermes version
 ```

--- a/sei/tasks/act-1/ibc_relayer.md
+++ b/sei/tasks/act-1/ibc_relayer.md
@@ -78,8 +78,8 @@ MNEMONIC_B='shaft pave alone age dolphin lab brave trick fatigue vivid social wo
 ## Download Hermes
 ```
 cd $HOME
-wget https://github.com/informalsystems/ibc-rs/releases/download/v1.0.0-rc.0/hermes-v1.0.0-rc.0-x86_64-unknown-linux-gnu.zip
-unzip hermes-v1.0.0-rc.0-x86_64-unknown-linux-gnu.zip
+wget https://github.com/informalsystems/hermes/releases/download/v1.2.0/hermes-v1.2.0-x86_64-unknown-linux-gnu.zip
+unzip hermes-v1.2.0-x86_64-unknown-linux-gnu.zip
 sudo mv hermes /usr/local/bin
 hermes version
 ```


### PR DESCRIPTION
[Hermes v1.1.0](https://github.com/informalsystems/hermes/releases/tag/v1.1.0) is an internal restructure.

[Hermes v1.2.0](https://github.com/informalsystems/hermes/releases/tag/v1.2.0) adds support for Ed25519 keys, health checking that respects `min_gas_price` and more.